### PR TITLE
clientversion-h

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -17,7 +17,7 @@
 #define CLIENT_VERSION_MAJOR 0
 #define CLIENT_VERSION_MINOR 12
 #define CLIENT_VERSION_REVISION 1
-#define CLIENT_VERSION_BUILD 3
+#define CLIENT_VERSION_BUILD 6
 
 //! Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE true
@@ -26,7 +26,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2017
+#define COPYRIGHT_YEAR 2018
 
 #endif //HAVE_CONFIG_H
 


### PR DESCRIPTION
without this change the windows exe's properties-details still shows as file-version and product-version information as '0.12.1.3' and not '0.12.1.6'
![image-qt](https://user-images.githubusercontent.com/13804605/39274864-406dbb1a-48db-11e8-986a-5f239a361e77.png)
