### PR TITLE
delete link from PrivateSend helpmsg

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -158,7 +158,6 @@ your funds will already be anonymized. No additional waiting is required.</li> \
 This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. \
 It can only do this, however, if you have automatic backups enabled.<br> \
 Consequently, users who have backups disabled will also have PrivateSend disabled. <hr>\
-For more info see <a href=\"https://zeroonecoin.atlassian.net/wiki/display/DOC/PrivateSend\">https://zeroonecoin.atlassian.net/wiki/display/DOC/PrivateSend</a> \
         "));
         ui->aboutMessage->setWordWrap(true);
         ui->helpMessage->setVisible(false);


### PR DESCRIPTION
From PrivateSend helpmsg: deleted: "For more info see <a href=\"https://zeroonecoin.atlassian.net/wiki/display/DOC/PrivateSend\">https://zeroonecoin.atlassian.net/wiki/display/DOC/PrivateSend</a> "